### PR TITLE
Add pkg-config dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update -qq
-RUN apt-get install -y python python-dev python-pip python-scipy
+RUN apt-get install -y python python-dev python-pip python-scipy pkg-config
 
 # Inline heavy dependencies to use container caching.
 RUN pip install numpy


### PR DESCRIPTION
During the matplotlib installation, it is complaining that `pkg-config` is not install
(see build failure https://hub.docker.com/r/dbhi/arrc/builds/bhem3py5kz2m2yb8rsl7zjm/)
which results in a build failure.

Signed-off-by: Byron Ruth b@devel.io
